### PR TITLE
feat(api): add custom extra link tags

### DIFF
--- a/chromium.go
+++ b/chromium.go
@@ -40,6 +40,9 @@ const failOnConsoleExceptions string = "failOnConsoleExceptions" // Return a 409
 // CSS
 const emulatedMediaType string = "emulatedMediaType" // The media type to emulate, either "screen" or "print" - empty means "print"
 
+// Custom Tags
+const extraLinkTags string = "extraLinkTags" // Add custom tags
+
 // PDF
 const pdfFormat string = "pdfFormat" // The PDF format of the resulting PDF
 
@@ -182,4 +185,10 @@ func (req *chromiumRequest) EmulatedMediaType(mediaType string) {
 // PDFFormat sets pdfFormat form field
 func (req *chromiumRequest) PDFFormat(format string) {
 	req.values[pdfFormat] = format
+}
+
+// ExtraLinkTags set up custom tags!
+// example:'extraLinkTags="[{\"href\":\"https://my.cdn.css\"}]"'
+func (req *chromiumRequest) ExtraLinkTags(link string) {
+	req.values[extraLinkTags] = link
 }


### PR DESCRIPTION
The form fields extraLinkTags and extraScriptTags (JSON format) allows you to add <link> and <script> HTML elements with remote paths.

For instance:
```

curl \
--request POST 'http://localhost:3000/forms/chromium/convert/url' \
--form 'url="https://my.url"' \
--form 'extraLinkTags="[{\"href\":\"https://my.cdn.css\"}]"' \
--form 'extraScriptTags="[{\"src\":\"https://my.cdn.js\"}]"' \
-o my.pdf
```

To use:

```
...
        var extraLinkTags = make(map[string]string)
	cssLink := CDNBaseURL + customCSS
	extraLinkTags[href] = cssLink
	jsonData, err := json.Marshal(extraLinkTags)
	if err != nil {
		return false, fmt.Errorf("cannot marshal extraTags to json, error: %w", err)
	}
	req.ExtraLinkTags(string(jsonData))
...
```